### PR TITLE
importing the movie dependency container and recognizing the infra entities by typeform

### DIFF
--- a/src/shared/infra/database/TypeormClient.ts
+++ b/src/shared/infra/database/TypeormClient.ts
@@ -1,10 +1,12 @@
 import { envConfig } from "@/config/env/EnvConfig";
 import { DataSource } from "typeorm";
+import { UserEntity } from "./entities/UserEntity";
+import { MovieEntity } from "./entities/MovieEntity";
 
 export const AppDataSource = new DataSource({
   type: "postgres",
   url: envConfig.getDbUrl(),
-  entities: [],
+  entities: [UserEntity, MovieEntity],
   synchronize: true,
 });
 

--- a/src/shared/infra/di/container.ts
+++ b/src/shared/infra/di/container.ts
@@ -1,0 +1,1 @@
+import "@/modules/movies/infra/di/container";


### PR DESCRIPTION
This imports the movies container into the shared container so that it is accessible within main.
This also makes TypeForm recognize UserEntity and MovieEntity as representations of database entities.